### PR TITLE
feat(setup): add --remove flag and fix UTF-8 profile path read

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -52,5 +52,9 @@ pub enum Commands {
     /// Diagnose PATH and SDK resolution issues
     Doctor,
     /// Create the dver dotnet shim and add it to PATH
-    Setup,
+    Setup {
+        /// Undo what `dver setup` did: remove the PATH entry, PowerShell profile hook, and shim directory
+        #[arg(long)]
+        remove: bool,
+    },
 }

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -146,6 +146,74 @@ fn print_setup_report(shims_dir: &Path, report: &SetupReport) {
     }
 }
 
+pub fn remove_setup() -> Result<(), Box<dyn std::error::Error>> {
+    println!("{}", setup_color("== dver setup --remove ==", SetupStyle::Title));
+    println!(
+        "{}",
+        setup_color(
+            "Undoing PATH entry, shell profile hook, and shim directory created by `dver setup`.",
+            SetupStyle::Dim
+        )
+    );
+    println!();
+
+    let shims_dir = get_shims_dir().ok_or("Could not determine dver shims directory")?;
+
+    remove_configuration()?;
+
+    let shims_removed = if shims_dir.exists() {
+        fs::remove_dir_all(&shims_dir)?;
+        true
+    } else {
+        false
+    };
+
+    println!(
+        "{} {}",
+        setup_color("[OK]", SetupStyle::Ok),
+        setup_color("Setup configuration removed", SetupStyle::Title)
+    );
+    println!(
+        "  {}",
+        setup_color(
+            format!(
+                "shim directory: {} ({})",
+                shims_dir.display(),
+                if shims_removed { "removed" } else { "not present" }
+            ),
+            SetupStyle::Info
+        )
+    );
+    println!(
+        "  {}",
+        setup_color(
+            "Managed SDKs and default-version selection were left untouched.",
+            SetupStyle::Dim
+        )
+    );
+    println!();
+    println!("{}", setup_color("Next steps", SetupStyle::Section));
+    if cfg!(windows) {
+        println!(
+            "  {}",
+            setup_color(
+                "Open a fresh PowerShell tab so the updated PATH and profile take effect.",
+                SetupStyle::Info
+            )
+        );
+    } else {
+        println!(
+            "  {}",
+            setup_color(
+                "Open a new terminal session so the updated shell profile is loaded.",
+                SetupStyle::Info
+            )
+        );
+    }
+
+    Ok(())
+}
+
 pub fn ensure_shims_exist() -> Result<(), Box<dyn std::error::Error>> {
     let shims_dir = get_shims_dir().ok_or("Could not determine dver shims directory")?;
     ensure_dir(&shims_dir)?;
@@ -372,13 +440,16 @@ pub fn windows_powershell_profile_paths() -> Vec<PathBuf> {
         let output = std::process::Command::new(shell)
             .arg("-NoProfile")
             .arg("-Command")
-            .arg("$PROFILE.CurrentUserCurrentHost")
+            .arg(
+                "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; \
+                 Write-Output $PROFILE.CurrentUserCurrentHost",
+            )
             .output();
 
         if let Ok(output) = output {
             if output.status.success() {
                 let stdout = String::from_utf8_lossy(&output.stdout);
-                let profile = stdout.trim();
+                let profile = stdout.trim().trim_start_matches('\u{feff}');
                 if !profile.is_empty() {
                     let profile_path = PathBuf::from(profile);
                     if !profiles.iter().any(|existing| existing == &profile_path) {

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -162,8 +162,20 @@ pub fn remove_setup() -> Result<(), Box<dyn std::error::Error>> {
     remove_configuration()?;
 
     let shims_removed = if shims_dir.exists() {
-        fs::remove_dir_all(&shims_dir)?;
-        true
+        match fs::remove_dir_all(&shims_dir) {
+            Ok(()) => true,
+            Err(error) if is_locked_file_error(&error) => {
+                return Err(format!(
+                    "Could not remove shim directory {} because a file inside is locked \
+                     (often a 'dotnet' shim still in use by another shell). \
+                     Close any open terminals or processes using dver, then re-run \
+                     'dver setup --remove'. Underlying error: {error}",
+                    shims_dir.display()
+                )
+                .into());
+            }
+            Err(error) => return Err(error.into()),
+        }
     } else {
         false
     };
@@ -688,6 +700,22 @@ fn remove_config_block(existing: &str) -> String {
     }
 
     result
+}
+
+fn is_locked_file_error(error: &std::io::Error) -> bool {
+    if error.kind() == std::io::ErrorKind::PermissionDenied {
+        return true;
+    }
+
+    #[cfg(windows)]
+    {
+        // ERROR_ACCESS_DENIED = 5, ERROR_SHARING_VIOLATION = 32, ERROR_LOCK_VIOLATION = 33
+        if let Some(code) = error.raw_os_error() {
+            return matches!(code, 5 | 32 | 33);
+        }
+    }
+
+    false
 }
 
 #[cfg(all(test, unix))]

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,8 +65,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Commands::Doctor => {
             commands::doctor::run_doctor_checks()?;
         }
-        Commands::Setup => {
-            commands::setup::move_to_top_of_path()?;
+        Commands::Setup { remove } => {
+            if *remove {
+                commands::setup::remove_setup()?;
+            } else {
+                commands::setup::move_to_top_of_path()?;
+            }
         }
     }
 


### PR DESCRIPTION
- Added `dver setup --remove` to undo what `setup` does: strip the HKCU PATH entry, remove the dver block from each PowerShell/rc-file profile, and delete the shim directory. Managed SDKs and the default-version selection are left untouched.
- Fixed `windows_powershell_profile_paths` to set `[Console]::OutputEncoding = UTF8` before reading `$PROFILE.CurrentUserCurrentHost`. Without this, non-ASCII characters in the user profile path (e.g. on OneDrive Known Folder Move with accented usernames) were mangled and the subsequent profile write failed with "Access is denied."
- Strip a leading UTF-8 BOM from the captured profile path defensively.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--remove` flag to the setup command, enabling users to undo previous setup operations and remove generated configuration and shim files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->