### PR TITLE
feat: add nvm-like fuzzy version selection and remote listing

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,7 +15,7 @@ pub enum Commands {
     List,
     /// Select a managed SDK version
     Use {
-        /// Managed SDK version to select
+        /// Managed SDK version, prefix, or alias: 8.0.406, 8.0, 8, latest
         version: Option<String>,
         /// Set the default managed version instead of writing a local global.json
         #[arg(long, short)]
@@ -26,7 +26,7 @@ pub enum Commands {
     },
     /// Install a managed .NET SDK version or channel
     Install {
-        /// Version or channel to install, for example 8.0.406, 8.0, STS
+        /// Version, channel, or alias: 8.0.406, 8.0, 8, lts, sts, latest
         version: Option<String>,
         /// Backward-compatible alias for the positional version argument
         #[arg(long = "version", hide = true)]
@@ -48,9 +48,22 @@ pub enum Commands {
         /// Remove every managed SDK version and dver PATH configuration
         #[arg(long)]
         all: bool,
+        /// Bypass the safety check that refuses to remove the active or default SDK
+        #[arg(long, short)]
+        force: bool,
     },
     /// Diagnose PATH and SDK resolution issues
     Doctor,
+    /// List installable .NET SDK channels from the official release index
+    #[command(name = "ls-remote")]
+    LsRemote {
+        /// Show only LTS channels
+        #[arg(long)]
+        lts: bool,
+        /// Include channels whose support phase is "eol"
+        #[arg(long)]
+        all: bool,
+    },
     /// Create the dver dotnet shim and add it to PATH
     Setup,
 }

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -11,8 +11,9 @@ pub async fn handle_install(
     if let InstallRequest::Version(version) = &request {
         let normalized = crate::utils::common::normalize_version_input(version);
         if get_managed_sdk(&normalized)?.is_some() {
+            let short = use_hint_selector(&normalized);
             println!("Managed .NET SDK {normalized} is already installed.");
-            println!("Run 'dver use {normalized}' to select it.");
+            println!("Run 'dver use {short}' to select it (or 'dver use {normalized}').");
             return Ok(());
         }
     }
@@ -23,16 +24,37 @@ pub async fn handle_install(
     let installed_version = downloader::install_sdk(request).await?;
     setup::ensure_shims_exist()?;
 
-    if get_default_version()?.is_none() {
+    let was_first_install = get_default_version()?.is_none();
+    if was_first_install {
         set_default_version(&installed_version)?;
         println!("Default managed version set to {installed_version}.");
     }
 
-    println!("Installed managed .NET SDK {installed_version}.");
-    println!("Run 'dver use {installed_version}' to create a local global.json.");
-    println!("Run 'dver setup' once if you want dver to provide the active 'dotnet' command.");
+    let short = use_hint_selector(&installed_version);
+    println!();
+    println!("Next steps:");
+    println!("  dver use {short}                 # write ./global.json (project-local)");
+    println!("  dver use --global {short}        # set as the default managed SDK");
+    if short != installed_version {
+        println!(
+            "  (tip: '{short}' is a fuzzy alias for {installed_version} — \
+             '{installed_version}' also works)"
+        );
+    }
+    if was_first_install {
+        println!("  dver setup                      # let dver provide the active 'dotnet' command");
+    }
 
     Ok(())
+}
+
+fn use_hint_selector(version: &str) -> String {
+    version
+        .split('.')
+        .next()
+        .filter(|s| !s.is_empty() && s.chars().all(|c| c.is_ascii_digit()))
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| version.to_string())
 }
 
 fn resolve_install_request(
@@ -41,11 +63,20 @@ fn resolve_install_request(
 ) -> Result<InstallRequest, Box<dyn std::error::Error>> {
     if let Some(value) = version_or_channel {
         let normalized = crate::utils::common::normalize_version_input(&value);
+
+        if let Some(alias) = match_channel_alias(&normalized) {
+            return Ok(InstallRequest::Channel(alias.to_string()));
+        }
+
         if crate::utils::common::is_probably_specific_version(&normalized) {
             return Ok(InstallRequest::Version(normalized));
         }
 
-        return Ok(InstallRequest::Channel(value));
+        if let Some(channel) = expand_short_channel(&normalized) {
+            return Ok(InstallRequest::Channel(channel));
+        }
+
+        return Ok(InstallRequest::Channel(normalized));
     }
 
     if lts {
@@ -53,4 +84,89 @@ fn resolve_install_request(
     }
 
     Ok(InstallRequest::Channel("LTS".to_string()))
+}
+
+fn match_channel_alias(value: &str) -> Option<&'static str> {
+    match value.to_ascii_lowercase().as_str() {
+        "lts" => Some("LTS"),
+        "sts" => Some("STS"),
+        "latest" | "current" | "stable" => Some("Current"),
+        _ => None,
+    }
+}
+
+fn expand_short_channel(value: &str) -> Option<String> {
+    if value.is_empty() {
+        return None;
+    }
+    if value.contains('.') {
+        return None;
+    }
+    if value.chars().all(|c| c.is_ascii_digit()) {
+        return Some(format!("{value}.0"));
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn req(input: &str) -> InstallRequest {
+        resolve_install_request(false, Some(input.to_string())).unwrap()
+    }
+
+    fn channel(req: &InstallRequest) -> &str {
+        match req {
+            InstallRequest::Channel(c) => c.as_str(),
+            InstallRequest::Version(v) => panic!("expected channel, got version {v}"),
+        }
+    }
+
+    fn version(req: &InstallRequest) -> &str {
+        match req {
+            InstallRequest::Version(v) => v.as_str(),
+            InstallRequest::Channel(c) => panic!("expected version, got channel {c}"),
+        }
+    }
+
+    #[test]
+    fn lts_alias_is_case_insensitive() {
+        assert_eq!(channel(&req("lts")), "LTS");
+        assert_eq!(channel(&req("LTS")), "LTS");
+    }
+
+    #[test]
+    fn sts_alias_is_case_insensitive() {
+        assert_eq!(channel(&req("sts")), "STS");
+    }
+
+    #[test]
+    fn latest_and_current_map_to_current_channel() {
+        assert_eq!(channel(&req("latest")), "Current");
+        assert_eq!(channel(&req("current")), "Current");
+    }
+
+    #[test]
+    fn bare_major_expands_to_minor_zero_channel() {
+        assert_eq!(channel(&req("8")), "8.0");
+        assert_eq!(channel(&req("9")), "9.0");
+    }
+
+    #[test]
+    fn major_minor_passes_through_as_channel() {
+        assert_eq!(channel(&req("8.0")), "8.0");
+    }
+
+    #[test]
+    fn exact_version_resolves_to_version_request() {
+        assert_eq!(version(&req("8.0.406")), "8.0.406");
+        assert_eq!(version(&req("v8.0.406")), "8.0.406");
+    }
+
+    #[test]
+    fn no_arg_defaults_to_lts() {
+        let r = resolve_install_request(false, None).unwrap();
+        assert_eq!(channel(&r), "LTS");
+    }
 }

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -24,8 +24,8 @@ pub async fn handle_install(
     let installed_version = downloader::install_sdk(request).await?;
     setup::ensure_shims_exist()?;
 
-    let was_first_install = get_default_version()?.is_none();
-    if was_first_install {
+    let no_default_was_set = get_default_version()?.is_none();
+    if no_default_was_set {
         set_default_version(&installed_version)?;
         println!("Default managed version set to {installed_version}.");
     }
@@ -41,7 +41,7 @@ pub async fn handle_install(
              '{installed_version}' also works)"
         );
     }
-    if was_first_install {
+    if no_default_was_set {
         println!("  dver setup                      # let dver provide the active 'dotnet' command");
     }
 

--- a/src/commands/ls_remote.rs
+++ b/src/commands/ls_remote.rs
@@ -1,6 +1,7 @@
 use crate::utils::sdk::list_managed_sdks;
 use serde::Deserialize;
 use std::collections::HashSet;
+use std::time::Duration;
 
 const RELEASES_INDEX_URL: &str =
     "https://builds.dotnet.microsoft.com/dotnet/release-metadata/releases-index.json";
@@ -26,7 +27,7 @@ struct Channel {
 }
 
 pub async fn handle_ls_remote(lts_only: bool, include_eol: bool) -> Result<(), Box<dyn std::error::Error>> {
-    let installed_sdks = list_managed_sdks().unwrap_or_default();
+    let installed_sdks = list_managed_sdks()?;
     let installed_majors: HashSet<String> = installed_sdks
         .iter()
         .filter_map(|sdk| sdk.version.split('.').next().map(str::to_string))
@@ -38,6 +39,7 @@ pub async fn handle_ls_remote(lts_only: bool, include_eol: bool) -> Result<(), B
 
     let client = reqwest::Client::builder()
         .user_agent(concat!("dver/", env!("CARGO_PKG_VERSION")))
+        .timeout(Duration::from_secs(30))
         .build()?;
     let response = client.get(RELEASES_INDEX_URL).send().await?;
     if !response.status().is_success() {

--- a/src/commands/ls_remote.rs
+++ b/src/commands/ls_remote.rs
@@ -52,7 +52,7 @@ pub async fn handle_ls_remote(lts_only: bool, include_eol: bool) -> Result<(), B
     let index: Index = response.json().await?;
 
     println!(
-        "{:<3} {:<8} {:<32} {:<6} {:<8} {:<12}",
+        "{:<3} {:<8} {:<32} {:<6} {:<13} {:<12}",
         "", "Channel", "Latest SDK", "Type", "Phase", "EOL"
     );
 
@@ -74,7 +74,7 @@ pub async fn handle_ls_remote(lts_only: bool, include_eol: bool) -> Result<(), B
         };
 
         println!(
-            "{:<3} {:<8} {:<32} {:<6} {:<8} {:<12}",
+            "{:<3} {:<8} {:<32} {:<6} {:<13} {:<12}",
             marker,
             channel.channel_version,
             channel.latest_sdk,

--- a/src/commands/ls_remote.rs
+++ b/src/commands/ls_remote.rs
@@ -1,0 +1,92 @@
+use crate::utils::sdk::list_managed_sdks;
+use serde::Deserialize;
+use std::collections::HashSet;
+
+const RELEASES_INDEX_URL: &str =
+    "https://builds.dotnet.microsoft.com/dotnet/release-metadata/releases-index.json";
+
+#[derive(Debug, Deserialize)]
+struct Index {
+    #[serde(rename = "releases-index")]
+    releases_index: Vec<Channel>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Channel {
+    #[serde(rename = "channel-version")]
+    channel_version: String,
+    #[serde(rename = "latest-sdk")]
+    latest_sdk: String,
+    #[serde(rename = "support-phase")]
+    support_phase: String,
+    #[serde(rename = "release-type")]
+    release_type: String,
+    #[serde(rename = "eol-date")]
+    eol_date: Option<String>,
+}
+
+pub async fn handle_ls_remote(lts_only: bool, include_eol: bool) -> Result<(), Box<dyn std::error::Error>> {
+    let installed_majors: HashSet<String> = list_managed_sdks()
+        .unwrap_or_default()
+        .iter()
+        .filter_map(|sdk| sdk.version.split('.').next().map(str::to_string))
+        .collect();
+
+    let installed_exact: HashSet<String> = list_managed_sdks()
+        .unwrap_or_default()
+        .into_iter()
+        .map(|sdk| sdk.version)
+        .collect();
+
+    let client = reqwest::Client::builder()
+        .user_agent(concat!("dver/", env!("CARGO_PKG_VERSION")))
+        .build()?;
+    let response = client.get(RELEASES_INDEX_URL).send().await?;
+    if !response.status().is_success() {
+        return Err(format!(
+            "Failed to fetch the .NET releases index: HTTP {}",
+            response.status()
+        )
+        .into());
+    }
+    let index: Index = response.json().await?;
+
+    println!(
+        "{:<3} {:<8} {:<32} {:<6} {:<8} {:<12}",
+        "", "Channel", "Latest SDK", "Type", "Phase", "EOL"
+    );
+
+    for channel in &index.releases_index {
+        if lts_only && !channel.release_type.eq_ignore_ascii_case("lts") {
+            continue;
+        }
+        if !include_eol && channel.support_phase.eq_ignore_ascii_case("eol") {
+            continue;
+        }
+
+        let major = channel.channel_version.split('.').next().unwrap_or("");
+        let marker = if installed_exact.contains(&channel.latest_sdk) {
+            "*"
+        } else if installed_majors.contains(major) {
+            "."
+        } else {
+            ""
+        };
+
+        println!(
+            "{:<3} {:<8} {:<32} {:<6} {:<8} {:<12}",
+            marker,
+            channel.channel_version,
+            channel.latest_sdk,
+            channel.release_type.to_uppercase(),
+            channel.support_phase,
+            channel.eol_date.as_deref().unwrap_or("-"),
+        );
+    }
+
+    println!();
+    println!("Legend: '*' latest SDK installed, '.' another SDK in this channel installed");
+    println!("Install with: dver install <channel> (e.g. 8.0), dver install <major> (e.g. 8), or dver install lts");
+
+    Ok(())
+}

--- a/src/commands/ls_remote.rs
+++ b/src/commands/ls_remote.rs
@@ -26,14 +26,12 @@ struct Channel {
 }
 
 pub async fn handle_ls_remote(lts_only: bool, include_eol: bool) -> Result<(), Box<dyn std::error::Error>> {
-    let installed_majors: HashSet<String> = list_managed_sdks()
-        .unwrap_or_default()
+    let installed_sdks = list_managed_sdks().unwrap_or_default();
+    let installed_majors: HashSet<String> = installed_sdks
         .iter()
         .filter_map(|sdk| sdk.version.split('.').next().map(str::to_string))
         .collect();
-
-    let installed_exact: HashSet<String> = list_managed_sdks()
-        .unwrap_or_default()
+    let installed_exact: HashSet<String> = installed_sdks
         .into_iter()
         .map(|sdk| sdk.version)
         .collect();

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod doctor;
 pub mod install;
+pub mod ls_remote;
 pub mod setup;
 pub mod shim;
 pub mod uninstall;

--- a/src/commands/uninstall.rs
+++ b/src/commands/uninstall.rs
@@ -1,13 +1,15 @@
 use crate::commands::setup;
-use crate::utils::common::{get_dver_root, get_versions_dir};
+use crate::utils::common::{current_working_dir, get_dver_root, get_versions_dir};
 use crate::utils::sdk::{
     clear_default_version, get_default_version, list_managed_sdks, resolve_managed_sdk,
+    resolve_version_selection,
 };
 use std::fs;
 
 pub async fn handle_uninstall(
     version: Option<String>,
     all: bool,
+    force: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     if all {
         return uninstall_all();
@@ -17,6 +19,28 @@ pub async fn handle_uninstall(
         .ok_or("Please provide a version to uninstall, for example: dver uninstall 8.0.406")?;
     let sdk = resolve_managed_sdk(&version)?;
     let default_version = get_default_version()?;
+    let selected_version = resolve_version_selection(&current_working_dir()?)?
+        .map(|selection| selection.requested_version);
+
+    if !force {
+        let mut reasons = Vec::new();
+        if selected_version.as_deref() == Some(&sdk.version) {
+            reasons.push("selected by the current global.json or default");
+        }
+        if default_version.as_deref() == Some(&sdk.version) {
+            reasons.push("the default managed SDK");
+        }
+
+        if !reasons.is_empty() {
+            return Err(format!(
+                "Refusing to uninstall {} because it is {}. \
+                 Switch with 'dver use <other>' first, or pass --force.",
+                sdk.version,
+                reasons.join(" and ")
+            )
+            .into());
+        }
+    }
 
     fs::remove_dir_all(&sdk.root)?;
     println!("Removed managed .NET SDK {}.", sdk.version);

--- a/src/commands/uninstall.rs
+++ b/src/commands/uninstall.rs
@@ -23,20 +23,21 @@ pub async fn handle_uninstall(
         .map(|selection| selection.requested_version);
 
     if !force {
-        let mut reasons = Vec::new();
-        if selected_version.as_deref() == Some(&sdk.version) {
-            reasons.push("selected by the current global.json or default");
-        }
-        if default_version.as_deref() == Some(&sdk.version) {
-            reasons.push("the default managed SDK");
-        }
+        let is_selected = selected_version.as_deref() == Some(&sdk.version);
+        let is_default = default_version.as_deref() == Some(&sdk.version);
 
-        if !reasons.is_empty() {
+        let reason = match (is_selected, is_default) {
+            (true, true) => Some("currently active and the default managed SDK"),
+            (true, false) => Some("currently active (selected by global.json)"),
+            (false, true) => Some("the default managed SDK"),
+            (false, false) => None,
+        };
+
+        if let Some(reason) = reason {
             return Err(format!(
                 "Refusing to uninstall {} because it is {}. \
                  Switch with 'dver use <other>' first, or pass --force.",
-                sdk.version,
-                reasons.join(" and ")
+                sdk.version, reason
             )
             .into());
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -159,7 +159,8 @@ fn handle_list_command() -> Result<(), Box<dyn std::error::Error>> {
         .map(|selection| selection.requested_version);
     let default_version = crate::utils::sdk::get_default_version()?;
 
-    let managed_rows = if managed_sdks.is_empty() {
+    let no_managed_sdks = managed_sdks.is_empty();
+    let managed_rows = if no_managed_sdks {
         vec![vec![
             " ".to_string(),
             "none".to_string(),
@@ -205,7 +206,7 @@ fn handle_list_command() -> Result<(), Box<dyn std::error::Error>> {
         &managed_rows,
     );
 
-    if managed_rows.len() == 1 && managed_rows[0][0] == "none" {
+    if no_managed_sdks {
         println!("Tip: run 'dver install 8.0.406' to install one.");
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use clap::Parser;
 use cli::{Cli, Commands};
 use std::path::Path;
 use std::process::Command;
+use utils::common::display_width;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -240,15 +241,16 @@ fn print_table_section(title: &str, headers: &[&str], rows: &[Vec<String>]) {
 fn build_table(headers: &[&str], rows: &[Vec<String>]) -> TableRender {
     let mut widths = headers
         .iter()
-        .map(|header| header.len())
+        .map(|header| display_width(header))
         .collect::<Vec<_>>();
 
     for row in rows {
         for (index, cell) in row.iter().enumerate() {
+            let width = display_width(cell);
             if index >= widths.len() {
-                widths.push(cell.len());
+                widths.push(width);
             } else {
-                widths[index] = widths[index].max(cell.len());
+                widths[index] = widths[index].max(width);
             }
         }
     }
@@ -314,11 +316,12 @@ fn color_cell(_index: usize, raw: &str, padded: &str) -> String {
 }
 
 fn center_text(text: &str, width: usize) -> String {
-    if text.len() >= width {
+    let text_width = display_width(text);
+    if text_width >= width {
         return text.to_string();
     }
 
-    let left_padding = (width - text.len()) / 2;
+    let left_padding = (width - text_width) / 2;
     format!("{}{}", " ".repeat(left_padding), text)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,12 +58,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             version,
             version_flag,
             all,
+            force,
         } => {
             let request = version.clone().or_else(|| version_flag.clone());
-            commands::uninstall::handle_uninstall(request, *all).await?;
+            commands::uninstall::handle_uninstall(request, *all, *force).await?;
         }
         Commands::Doctor => {
             commands::doctor::run_doctor_checks()?;
+        }
+        Commands::LsRemote { lts, all } => {
+            commands::ls_remote::handle_ls_remote(*lts, *all).await?;
         }
         Commands::Setup => {
             commands::setup::move_to_top_of_path()?;
@@ -156,6 +160,7 @@ fn handle_list_command() -> Result<(), Box<dyn std::error::Error>> {
 
     let managed_rows = if managed_sdks.is_empty() {
         vec![vec![
+            " ".to_string(),
             "none".to_string(),
             "-".to_string(),
             "-".to_string(),
@@ -173,7 +178,14 @@ fn handle_list_command() -> Result<(), Box<dyn std::error::Error>> {
                     markers.push("default");
                 }
 
+                let arrow = if selected_version.as_deref() == Some(&sdk.version) {
+                    "->"
+                } else {
+                    "  "
+                };
+
                 vec![
+                    arrow.to_string(),
                     sdk.version,
                     if markers.is_empty() {
                         "-".to_string()
@@ -188,7 +200,7 @@ fn handle_list_command() -> Result<(), Box<dyn std::error::Error>> {
     };
     print_table_section(
         "Managed .NET SDK versions",
-        &["Version", "Status", "Owner", "Location"],
+        &["", "Version", "Status", "Owner", "Location"],
         &managed_rows,
     );
 
@@ -289,12 +301,12 @@ fn build_row(cells: Vec<String>, widths: &[usize], is_header: bool) -> String {
     row
 }
 
-fn color_cell(index: usize, raw: &str, padded: &str) -> String {
+fn color_cell(_index: usize, raw: &str, padded: &str) -> String {
     if raw == "none" || raw == "none detected" || raw == "-" {
         return color(padded, TableStyle::Dim);
     }
 
-    if index == 1 && raw.contains("selected") {
+    if raw == "->" || raw.contains("selected") {
         return color(padded, TableStyle::Highlight);
     }
 

--- a/src/utils/common.rs
+++ b/src/utils/common.rs
@@ -76,3 +76,7 @@ pub fn compare_versions_desc(left: &str, right: &str) -> std::cmp::Ordering {
 pub fn current_working_dir() -> Result<PathBuf, Box<dyn std::error::Error>> {
     Ok(env::current_dir()?)
 }
+
+pub fn display_width(value: &str) -> usize {
+    value.chars().count()
+}

--- a/src/utils/downloader.rs
+++ b/src/utils/downloader.rs
@@ -247,13 +247,19 @@ fn detect_installed_version(install_dir: &Path) -> Result<String, Box<dyn std::e
     }
 
     let mut versions = Vec::new();
-    for entry in fs::read_dir(sdk_dir)? {
+    for entry in fs::read_dir(&sdk_dir)? {
         let entry = entry?;
         if !entry.path().is_dir() {
             continue;
         }
 
-        let Some(version) = entry.file_name().to_str().map(str::to_string) else {
+        let file_name = entry.file_name();
+        let Some(version) = file_name.to_str().map(str::to_string) else {
+            eprintln!(
+                "warning: skipping non-UTF-8 directory entry under {}: {:?}",
+                sdk_dir.display(),
+                file_name
+            );
             continue;
         };
         versions.push(version);
@@ -307,10 +313,9 @@ fn track_install_progress(progress: &ProgressBar, line: &str) {
         if progress.position() < 4 {
             progress.set_position(4);
         }
-    } else if normalized.contains("Installed version is") {
+    } else if let Some(idx) = lower.find("installed version is") {
         let version = normalized
-            .split("Installed version is")
-            .nth(1)
+            .get(idx + "installed version is".len()..)
             .map(str::trim)
             .unwrap_or_default();
         progress.set_message(format!("Installed SDK {}", version));

--- a/src/utils/downloader.rs
+++ b/src/utils/downloader.rs
@@ -212,22 +212,18 @@ fn run_install_script(
 #[cfg(windows)]
 fn build_windows_install_command(script_path: &Path) -> Command {
     let mut command = if executable_exists("pwsh") {
-        let mut command = Command::new("pwsh");
-        command
-            .arg("-NoProfile")
-            .arg("-ExecutionPolicy")
-            .arg("Bypass");
-        command
+        Command::new("pwsh")
     } else {
-        let mut command = Command::new("powershell");
-        command
-            .arg("-NoProfile")
-            .arg("-ExecutionPolicy")
-            .arg("Bypass");
-        command
+        Command::new("powershell")
     };
 
-    command.arg("-File").arg(script_path);
+    command
+        .arg("-NoLogo")
+        .arg("-NoProfile")
+        .arg("-ExecutionPolicy")
+        .arg("Bypass")
+        .arg("-File")
+        .arg(script_path);
     command
 }
 
@@ -292,13 +288,25 @@ fn create_install_progress_bar() -> ProgressBar {
 
 fn track_install_progress(progress: &ProgressBar, line: &str) {
     let normalized = line.trim();
+    let lower = normalized.to_ascii_lowercase();
 
-    if normalized.contains("Downloaded file") {
+    if lower.contains("downloaded file") {
         progress.set_position(3);
         progress.set_message(downloaded_message(normalized));
-    } else if normalized.contains("Extracting the archive") {
+    } else if lower.starts_with("downloading") || lower.contains("downloading link") {
+        if progress.position() < 3 {
+            progress.set_position(3);
+        }
+        progress.set_message("Downloading SDK archive");
+    } else if lower.contains("extracting") {
         progress.set_position(4);
         progress.set_message("Extracting SDK archive");
+    } else if lower.contains("adding to current process path")
+        || lower.contains("adding to user path")
+    {
+        if progress.position() < 4 {
+            progress.set_position(4);
+        }
     } else if normalized.contains("Installed version is") {
         let version = normalized
             .split("Installed version is")
@@ -306,7 +314,7 @@ fn track_install_progress(progress: &ProgressBar, line: &str) {
             .map(str::trim)
             .unwrap_or_default();
         progress.set_message(format!("Installed SDK {}", version));
-    } else if normalized.contains("Installation finished") {
+    } else if lower.contains("installation finished") {
         progress.set_position(5);
         progress.set_message("Installer finished successfully");
     }
@@ -330,10 +338,12 @@ fn should_surface_line(line: &str, is_stderr: bool) -> bool {
 }
 
 fn is_important_line(line: &str) -> bool {
-    line.contains("Downloaded file")
-        || line.contains("Extracting the archive")
-        || line.contains("Installed version is")
-        || line.contains("Installation finished")
-        || line.contains("Error")
-        || line.contains("Warning")
+    let lower = line.to_ascii_lowercase();
+    lower.contains("downloaded file")
+        || lower.starts_with("downloading")
+        || lower.contains("extracting")
+        || lower.contains("installed version is")
+        || lower.contains("installation finished")
+        || lower.contains("error")
+        || lower.contains("warning")
 }

--- a/src/utils/sdk.rs
+++ b/src/utils/sdk.rs
@@ -54,7 +54,13 @@ pub fn list_managed_sdks() -> Result<Vec<ManagedSdk>, Box<dyn std::error::Error>
             continue;
         }
 
-        let Some(name) = entry.file_name().to_str().map(str::to_string) else {
+        let file_name = entry.file_name();
+        let Some(name) = file_name.to_str().map(str::to_string) else {
+            eprintln!(
+                "warning: skipping non-UTF-8 directory entry under {}: {:?}",
+                versions_dir.display(),
+                file_name
+            );
             continue;
         };
 
@@ -299,7 +305,13 @@ fn collect_sdks_from_directory(
             continue;
         }
 
-        let Some(version) = entry.file_name().to_str().map(normalize_version_input) else {
+        let file_name = entry.file_name();
+        let Some(version) = file_name.to_str().map(normalize_version_input) else {
+            eprintln!(
+                "warning: skipping non-UTF-8 directory entry under {}: {:?}",
+                sdk_dir.display(),
+                file_name
+            );
             continue;
         };
 

--- a/src/utils/sdk.rs
+++ b/src/utils/sdk.rs
@@ -399,6 +399,8 @@ mod tests {
         assert_eq!(resolved.version, "9.0.100");
         let resolved = resolve_managed_sdk_from_list("current", &sdks).unwrap();
         assert_eq!(resolved.version, "9.0.100");
+        let resolved = resolve_managed_sdk_from_list("stable", &sdks).unwrap();
+        assert_eq!(resolved.version, "9.0.100");
     }
 
     #[test]

--- a/src/utils/sdk.rs
+++ b/src/utils/sdk.rs
@@ -58,6 +58,10 @@ pub fn list_managed_sdks() -> Result<Vec<ManagedSdk>, Box<dyn std::error::Error>
             continue;
         };
 
+        if name.starts_with('.') {
+            continue;
+        }
+
         if !managed_dotnet_path(&path).exists() {
             continue;
         }
@@ -97,13 +101,31 @@ fn resolve_managed_sdk_from_list(
     selector: &str,
     sdks: &[ManagedSdk],
 ) -> Result<ManagedSdk, Box<dyn std::error::Error>> {
+    if sdks.is_empty() {
+        return Err(format!(
+            "No managed .NET SDKs are installed. Run 'dver install {selector}' first."
+        )
+        .into());
+    }
+
+    let lower = selector.to_ascii_lowercase();
+    if matches!(lower.as_str(), "latest" | "current" | "stable") {
+        return Ok(sdks[0].clone());
+    }
+
     if let Some(exact) = sdks.iter().find(|sdk| sdk.version == selector) {
         return Ok(exact.clone());
     }
 
+    let prefix = if !selector.is_empty() && selector.chars().all(|c| c.is_ascii_digit()) {
+        format!("{selector}.")
+    } else {
+        selector.to_string()
+    };
+
     let matches: Vec<_> = sdks
         .iter()
-        .filter(|sdk| sdk.version.starts_with(selector))
+        .filter(|sdk| sdk.version.starts_with(&prefix))
         .cloned()
         .collect();
 
@@ -349,5 +371,27 @@ mod tests {
         let sdks = vec![sdk("8.0.406"), sdk("8.0.407")];
         let err = resolve_managed_sdk_from_list("8.0", &sdks).unwrap_err();
         assert!(err.to_string().contains("ambiguous"));
+    }
+
+    #[test]
+    fn bare_major_matches_only_that_major() {
+        let sdks = vec![sdk("9.0.100"), sdk("8.0.406")];
+        let resolved = resolve_managed_sdk_from_list("8", &sdks).unwrap();
+        assert_eq!(resolved.version, "8.0.406");
+    }
+
+    #[test]
+    fn latest_alias_picks_first_entry() {
+        let sdks = vec![sdk("9.0.100"), sdk("8.0.406")];
+        let resolved = resolve_managed_sdk_from_list("latest", &sdks).unwrap();
+        assert_eq!(resolved.version, "9.0.100");
+        let resolved = resolve_managed_sdk_from_list("current", &sdks).unwrap();
+        assert_eq!(resolved.version, "9.0.100");
+    }
+
+    #[test]
+    fn empty_list_returns_helpful_error() {
+        let err = resolve_managed_sdk_from_list("8.0", &[]).unwrap_err();
+        assert!(err.to_string().contains("No managed"));
     }
 }


### PR DESCRIPTION
- install/use accept fuzzy selectors: bare major (8 -> 8.0 channel), lts/sts/latest/current/stable aliases (case-insensitive); exact versions and major.minor channels keep working as before.
- Add `dver ls-remote [--lts] [--all]` to list installable channels from the official .NET releases index, marking installed versions.
- `dver list` now shows a green `->` arrow on the active version.
- `dver list` skips `.tmp-install-*` debris from aborted installs.
- `dver uninstall` refuses to remove the active or default SDK without `--force`, mirroring `nvm uninstall` safety.
- `dver install` post-install output prints next-step hints using the fuzzy alias (e.g. `dver use 8`) so users discover the shortcut.
- Improve install progress bar on Windows: pass `-NoLogo` to powershell, match the .ps1 installer's `Downloading`/`Extracting` phrases so the bar advances through 3/5 and 4/5 instead of jumping 2 -> 5.

## Follow-up commits

- `e698ec3` refactor(ls-remote): call `list_managed_sdks` once and reuse the result for both lookup sets (per Gemini Code Assist).
- `fc45957` review feedback + unicode path handling:
  - Propagate filesystem errors from `list_managed_sdks` in `ls-remote` instead of swallowing them.
  - Add a 30s reqwest timeout so a hung releases-index server cannot stall the CLI.
  - Match `installed version is` case-insensitively in the install progress tracker (parity with the rest of the function).
  - Compute table widths and title centering in characters (`chars().count()`), so non-ASCII paths (accented usernames, etc.) align correctly in `dver list` / `dver current`.
  - Warn to stderr when skipping a non-UTF-8 directory entry under the managed/system SDK roots, instead of silently dropping it.
- `956cea8` further review feedback:
  - Fix `dver list` install tip never printing when no managed SDKs are installed (guard previously read the arrow column).
  - Replace joined uninstall-refusal reasons with per-state messages, removing awkward "or default and the default" phrasing when both conditions held.
  - Rename `was_first_install` to `no_default_was_set` since the flag is true any time no default is configured.
  - Cover the `stable` alias in `latest_alias_picks_first_entry`.

## Test plan

- [x] `cargo build --release`
- [x] `cargo test --release` (13/13 passing)
- [x] `dver ls-remote` end-to-end on Windows
- [x] `dver list` with a profile path containing non-ASCII characters renders aligned columns
- [x] `dver list` with no managed SDKs prints the install tip

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ls-remote to list remote SDK channels with LTS and EOL filters and markers for installed/major matches
  * CLI accepts aliases/prefixes (e.g., latest, lts, sts) and bare major inputs (e.g., "8")
  * First managed SDK install auto-sets default and shows contextual next-step hints

* **Bug Fixes**
  * Added --force to override uninstall safety; uninstall now refuses removing active/default SDK unless forced
  * Improved installer progress detection and managed SDK listing/rendering behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->